### PR TITLE
Fixed link to discord.js in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![devDependencies](https://david-dm.org/Hackzzila/krypton/dev-status.svg)](https://david-dm.org/Hackzzila/krypton?type=dev)
 [![npm](https://img.shields.io/npm/dt/krypton.svg)]()
 
-<p><b>Multithreaded audio library for Node.js. Provides behind-the-scenes audio support for <a href="discord.js">discord.js</a></b></p>
+<p><b>Multithreaded audio library for Node.js. Provides behind-the-scenes audio support for <a href="https://github.com/discordjs/discord.js">discord.js</a></b></p>
 
 `npm install krypton`
 


### PR DESCRIPTION
The `<a href="discord.js">discord.js</a>` tag in the README was redirecting to https://github.com/Hackzzila/krypton/blob/master/discord.js, which is not valid, instead of https://github.com/discordjs/discord.js. This PR fixes this mistake